### PR TITLE
WSSQL-25 Do not deref Null pointer from cache miss

### DIFF
--- a/esp/services/ws_sql/SQL2ECL/HPCCFileCache.cpp
+++ b/esp/services/ws_sql/SQL2ECL/HPCCFileCache.cpp
@@ -240,7 +240,12 @@ bool HPCCFileCache::cacheHpccFileByName(const char * filename)
 
 HPCCFilePtr HPCCFileCache::getHpccFileByName(const char * filename)
 {
-    return isHpccFileCached(filename) ? *(cache.getValue(filename)) : NULL;
+    HPCCFilePtr * hpccfile = cache.getValue(filename);
+
+    if (hpccfile)
+        return *hpccfile;
+
+    return NULL;
 }
 
 bool HPCCFileCache::isHpccFileCached(const char * filename)


### PR DESCRIPTION
Signed-off-by: rpastrana rodrigo.pastrana@lexisnexis.com
