### PR TITLE
WSSQL-39 - Restructuring getcluster info code

### DIFF
--- a/esp/scm/ws_sql.ecm
+++ b/esp/scm/ws_sql.ecm
@@ -181,7 +181,7 @@ ESPresponse [exceptions_inline] GetDBMetaDataResponse
     ESParray<ESPstruct HPCCTable, Table> Tables;
     integer TableCount;
     ESParray<ESPstruct HPCCQuerySet, QuerySet> QuerySets;
-    ESParray<ESPstruct TpCluster> TpClusters;
+    ESParray<string, ClusterName> ClusterNames;
 };
 
 ESPrequest GetResultsRequest

--- a/esp/services/ws_sql/ws_sqlService.hpp
+++ b/esp/services/ws_sql/ws_sqlService.hpp
@@ -58,8 +58,6 @@ private:
 
     IPropertyTree *cfg;
     std::map<std::string,std::string> cachedSQLQueries;
-    Owned<IEnvironmentFactory>  m_envFactory;
-    CTpWrapper                  m_TpWrapper;
 
 public:
     IMPLEMENT_IINTERFACE;


### PR DESCRIPTION
- ongetDBMetadata: Only produce cluster names
- onExecute methods should verify valid cluster names are being used (even on cached queries)

Signed-off-by: rpastrana rodrigo.pastrana@lexisnexis.com
