### PR TITLE
WSSQL-54 Allow parametrized fields of non-string type

### DIFF
--- a/esp/services/ws_sql/SQL2ECL/HPCCSQLTreeWalker.cpp
+++ b/esp/services/ws_sql/SQL2ECL/HPCCSQLTreeWalker.cpp
@@ -345,6 +345,9 @@ ISQLExpression * HPCCSQLTreeWalker::expressionTreeWalker(pANTLR3_BASE_TREE exprA
                     }
                 }
 
+                //Sets the ecltype of the field.
+                verifyColumn(tmpfve);
+
                 tmpexp.setown(tmpfve.getLink());
                 break;
             }
@@ -777,7 +780,7 @@ void HPCCSQLTreeWalker::verifyAndDisambiguateNameFromList(IArrayOf<ISQLExpressio
     }
 }
 
-void HPCCSQLTreeWalker::verifyColumn(SQLFieldValueExpression * col )
+void HPCCSQLTreeWalker::verifyColumn(SQLFieldValueExpression * col)
 {
     if (col)
     {

--- a/esp/services/ws_sql/ws_sqlService.cpp
+++ b/esp/services/ws_sql/ws_sqlService.cpp
@@ -677,7 +677,6 @@ bool CwssqlEx::onExecuteSQL(IEspContext &context, IEspExecuteSQLRequest &req, IE
         if (!context.validateFeatureAccess(WSSQLACCESS, SecAccess_Write, false))
             throw MakeStringException(-1, "Failed to execute SQL. Permission denied.");
 
-
         StringBuffer sqltext;
         StringBuffer ecltext;
         StringBuffer username;


### PR DESCRIPTION
Ensure whereclause fields are assigned correct ECL type
Signed-off-by: rpastrana <rodrigo.pastrana@lexisnexis.com>