### PR TITLE
WSSQL-65 There is no need to throw expt if tgt cluster is provided

### DIFF
--- a/esp/services/ws_sql/ws_sqlService.cpp
+++ b/esp/services/ws_sql/ws_sqlService.cpp
@@ -749,7 +749,7 @@ bool CwssqlEx::onExecuteSQL(IEspContext &context, IEspExecuteSQLRequest &req, IE
             {
                 ESPLOG(LogMax, "WsSQL: Processing call query...");
                 if (!isEmpty(cluster))
-                    throw MakeStringException(-1,"Cannot set target Cluster on a query of type CALL.");
+                    ESPLOG(LogMax, "WsSQL: Target Cluster was provided on a query of type CALL but will be ignored.");
 
                 WsEclWuInfo wsinfo("", parsedSQL->getQuerySetName(), parsedSQL->getStoredProcName(), username.str(), passwd);
                 compiledwuid.set(wsinfo.ensureWuid());


### PR DESCRIPTION


Signed-off-by: rpastrana <rodrigo.pastrana@lexisnexis.com>