### PR TITLE
WSSQL-78 Add support for constant selects

### DIFF
--- a/esp/services/ws_sql/SQL2ECL/ANTLR3c/HPCCSQL.g
+++ b/esp/services/ws_sql/SQL2ECL/ANTLR3c/HPCCSQL.g
@@ -588,7 +588,7 @@ select_statement
           ( where_clause )?
           ( groupby_clause )?
           ( having_clause )?
-        )
+        )?
 
         ( orderby_clause )?
         ( limit_clause )?

--- a/esp/services/ws_sql/SQL2ECL/ECLEngine.hpp
+++ b/esp/services/ws_sql/SQL2ECL/ECLEngine.hpp
@@ -41,6 +41,7 @@ private:
     static void findAppropriateIndex(StringArray * relindexes, HPCCSQLTreeWalker * selectsqlobj, StringBuffer & indexname);
     static bool processIndex(HPCCFile * indexfiletouse, StringBuffer & keyedandwild, HPCCSQLTreeWalker * selectsqlobj);
 
+    static void generateConstSelectDataset(HPCCSQLTreeWalker * selectsqlobj, IProperties* eclEntities,  const IArrayOf<ISQLExpression> & expectedcolumns, const char * datasource);
     static void generateSelectStruct(HPCCSQLTreeWalker * selectsqlobj, IProperties* eclEntities, const IArrayOf<ISQLExpression> & expectedcolumns, const char * datasource);
     static void addFilterClause(HPCCSQLTreeWalker * sqlobj, StringBuffer & sb);
     static void addHavingCluse(HPCCSQLTreeWalker * sqlobj, StringBuffer & sb);

--- a/esp/services/ws_sql/SQL2ECL/HPCCSQLTreeWalker.hpp
+++ b/esp/services/ws_sql/SQL2ECL/HPCCSQLTreeWalker.hpp
@@ -141,7 +141,6 @@ public:
     const IArrayOf<ISQLExpression>* getSelectList() const
     {
         return const_cast <const IArrayOf<ISQLExpression>*> (&selectList);
-        //return &selectList;
     }
 
     int getLimit() const


### PR DESCRIPTION
- Makes the from clause optional
- creates explicit dataset for constant select queries (select 1; for example)
        import std;
        SelectStruct := RECORD
        INTEGER ConstNum;
        END;
        TblDS0 := OUTPUT(DATASET([{ 1}],SelectStruct);
        OUTPUT(CHOOSEN(TblDS0, 1),NAMED('WSSQLSelectQueryResult'));

Signed-off-by: rpastrana <rodrigo.pastrana@lexisnexis.com>