### PR TITLE
WSSQL-48 Add related index support

### DIFF
--- a/esp/scm/ws_sql.ecm
+++ b/esp/scm/ws_sql.ecm
@@ -216,8 +216,36 @@ ESPresponse EchoResponse
     string Response;
 };
 
-ESPservice [version("3.01"), default_client_version("3.01"), exceptions_inline("./smc_xslt/exceptions.xslt")] wssql
+ESPStruct RelatedIndexSet
 {
+    String FileName;
+    ESParray<String, Index> Indexes;
+};
+
+ESPrequest GetRelatedIndexesRequest
+{
+    ESParray<String, FileName> FileNames;
+};
+
+ESPresponse GetRelatedIndexesResponse
+{
+    ESParray<ESPstruct RelatedIndexSet, RelatedIndexSet> RelatedIndexSets;
+};
+
+ESPrequest SetRelatedIndexesRequest
+{
+    ESParray<ESPstruct RelatedIndexSet, RelatedIndexSet> RelatedIndexSets;
+};
+
+ESPresponse SetRelatedIndexesResponse
+{
+    ESParray<ESPstruct RelatedIndexSet, RelatedIndexSet> RelatedIndexSets;
+};
+
+ESPservice [version("3.02"), default_client_version("3.02"), exceptions_inline("./smc_xslt/exceptions.xslt")] wssql
+{
+    ESPmethod [min_ver("3.02")] SetRelatedIndexes(SetRelatedIndexesRequest, SetRelatedIndexesResponse);
+    ESPmethod [min_ver("3.02")] GetRelatedIndexes(GetRelatedIndexesRequest, GetRelatedIndexesResponse);
     ESPmethod [] PrepareSQL(PrepareSQLRequest, PrepareSQLResponse);
     ESPmethod [] ExecuteSQL(ExecuteSQLRequest, ExecuteSQLResponse);
     ESPmethod [] ExecutePreparedSQL(ExecutePreparedSQLRequest, ExecutePreparedSQLResponse);

--- a/esp/services/ws_sql/SQL2ECL/HPCCFile.hpp
+++ b/esp/services/ws_sql/SQL2ECL/HPCCFile.hpp
@@ -249,6 +249,24 @@ public:
         }
     }
 
+    static bool parseOutRelatedIndexes(StringBuffer & description, StringBuffer & releatedIndexes)
+    {
+        if (description.length() > 0)
+        {
+            const char * head = strstr(description.str(), "XDBC:RelIndexes");
+            if (head && *head)
+            {
+                const char * tail = strchr(head, ']');
+                if (tail && *tail)
+                {
+                    description.remove(head-description.str(), tail-description.str()).trim();
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     void getRelatedIndexes(StringArray & indexes)
     {
         ForEachItemIn(c, relIndexFiles)

--- a/esp/services/ws_sql/SQL2ECL/HPCCFileCache.cpp
+++ b/esp/services/ws_sql/SQL2ECL/HPCCFileCache.cpp
@@ -125,7 +125,6 @@ bool HPCCFileCache::cacheAllHpccFiles(const char * filterby)
 }
 bool HPCCFileCache::updateHpccFileDescription(const char * filename, const char * user, const char * pass, const char * description)
 {
-    bool success = true;
     Owned<IUserDescriptor> userdesc;
     try
     {

--- a/esp/services/ws_sql/SQL2ECL/HPCCFileCache.hpp
+++ b/esp/services/ws_sql/SQL2ECL/HPCCFileCache.hpp
@@ -37,7 +37,10 @@ public:
 
     static HPCCFileCache * createFileCache(const char * username, const char * passwd);
     bool cacheAllHpccFiles(const char * filterby);
-    bool fetchHpccFilesByTableName(IArrayOf<SQLTable> * sqltables, HpccFiles * hpccfilecache);
+    bool fetchHpccFilesByTableName(IArrayOf<SQLTable> * sqltables);
+    static bool updateHpccFileDescription(const char * filename, const char * user, const char * pass, const char * description);
+    HPCCFile * fetchHpccFileByName(IUserDescriptor *user, const char * filename, bool namevalidated);
+    static HPCCFile * fetchHpccFileByName(const char * filename, const char * user, const char * pass, bool namevalidated);
     const char * cacheHpccFileByName(const char * filename, bool namevalidated = false);
     bool isHpccFileCached(const char * filename);
     HPCCFilePtr getHpccFileByName(const char * filename);

--- a/esp/services/ws_sql/ws_sqlService.cpp
+++ b/esp/services/ws_sql/ws_sqlService.cpp
@@ -709,43 +709,50 @@ bool CwssqlEx::getWUResult(IEspContext &context, const char * wuid, StringBuffer
 
 bool CwssqlEx::onSetRelatedIndexes(IEspContext &context, IEspSetRelatedIndexesRequest &req, IEspSetRelatedIndexesResponse &resp)
 {
-    if (!context.validateFeatureAccess(WSSQLACCESS, SecAccess_Read, false))
-        throw MakeStringException(-1, "Failed to execute SQL. Permission denied.");
+    if (!context.validateFeatureAccess(WSSQLACCESS, SecAccess_Write, false))
+        throw MakeStringException(-1, "WsSQL::SetRelatedIndexes failed to execute SQL. Permission denied.");
 
-    bool success = false;
     StringBuffer username;
     context.getUserID(username);
 
     const char* passwd = context.queryPassword();
 
     IArrayOf<IConstRelatedIndexSet>& relatedindexSets = req.getRelatedIndexSets();
+    if (relatedindexSets.length() == 0)
+        throw MakeStringException(-1, "WsSQL::SetRelatedIndexes empty request detected.");
+
     ForEachItemIn(relatedindexsetindex, relatedindexSets)
     {
         IConstRelatedIndexSet &relatedIndexSet = relatedindexSets.item(relatedindexsetindex);
         const char * fileName = relatedIndexSet.getFileName();
+
+        if (!fileName || !*fileName)
+            throw MakeStringException(-1, "WsSQL::SetRelatedIndexes error: Empty file name detected.");
+
         StringArray& indexHints = relatedIndexSet.getIndexes();
 
         Owned<HPCCFile> file = HPCCFileCache::fetchHpccFileByName(fileName,username.str(), passwd, false);
 
-        StringBuffer description;
-        if (file)
-        {
-            StringBuffer currentIndexes;
-            description = file->getDescription();
-            HPCCFile::parseOutRelatedIndexes(description, currentIndexes);
+        if (!file)
+            throw MakeStringException(-1, "WsSQL::SetRelatedIndexes error: could not find file: %s.", fileName);
 
+        StringBuffer description;
+
+        StringBuffer currentIndexes;
+        description = file->getDescription();
+        HPCCFile::parseOutRelatedIndexes(description, currentIndexes);
+
+        int indexHintsCount = indexHints.length();
+        if (indexHintsCount > 0)
+        {
             description.append("\nXDBC:RelIndexes=[");
-            int indexHintsCount = indexHints.length();
-            if (indexHintsCount > 0)
+            for(int indexHintIndex = 0; indexHintIndex < indexHintsCount; indexHintIndex++)
             {
-                for(int indexHintIndex = 0; indexHintIndex < indexHintsCount; indexHintIndex++)
-                {
-                    description.appendf("%s%c", indexHints.item(indexHintIndex), (indexHintIndex < indexHintsCount-1 ? ',' : ' '));
-                }
-                description.append("]\n");
-                HPCCFileCache::updateHpccFileDescription(fileName, username, passwd, description.str());
-                file->setDescription(description.str());
+                description.appendf("%s%c", indexHints.item(indexHintIndex), (indexHintIndex < indexHintsCount-1 ? ';' : ' '));
             }
+            description.append("]\n");
+            HPCCFileCache::updateHpccFileDescription(fileName, username, passwd, description.str());
+            file->setDescription(description.str());
         }
     }
 
@@ -761,7 +768,10 @@ bool CwssqlEx::onGetRelatedIndexes(IEspContext &context, IEspGetRelatedIndexesRe
         if (!context.validateFeatureAccess(WSSQLACCESS, SecAccess_Read, false))
             throw MakeStringException(-1, "Failed to execute SQL. Permission denied.");
 
-        bool success = false;
+        StringArray& filenames = req.getFileNames();
+        if (filenames.length() == 0)
+            throw MakeStringException(-1, "WsSQL::GetRelatedIndexes error: No filenames detected");
+
         StringBuffer username;
         context.getUserID(username);
 
@@ -769,20 +779,21 @@ bool CwssqlEx::onGetRelatedIndexes(IEspContext &context, IEspGetRelatedIndexesRe
 
         IArrayOf<IEspRelatedIndexSet> relatedindexSets;
 
-        StringArray& filenames = req.getFileNames();
         ForEachItemIn(filenameindex, filenames)
         {
             const char * fileName = filenames.item(filenameindex);
             Owned<HPCCFile> file = HPCCFileCache::fetchHpccFileByName(fileName,username.str(), passwd, false);
 
-            StringArray indexHints;
             if (file)
+            {
+                StringArray indexHints;
                 file->getRelatedIndexes(indexHints);
 
-            Owned<IEspRelatedIndexSet> relatedIndexSet = createRelatedIndexSet("", "");
-            relatedIndexSet->setFileName(fileName);
-            relatedIndexSet->setIndexes(indexHints);
-            relatedindexSets.append(*relatedIndexSet.getLink());
+                Owned<IEspRelatedIndexSet> relatedIndexSet = createRelatedIndexSet("", "");
+                relatedIndexSet->setFileName(fileName);
+                relatedIndexSet->setIndexes(indexHints);
+                relatedindexSets.append(*relatedIndexSet.getLink());
+            }
         }
 
         resp.setRelatedIndexSets(relatedindexSets);

--- a/esp/services/ws_sql/ws_sqlService.cpp
+++ b/esp/services/ws_sql/ws_sqlService.cpp
@@ -731,20 +731,20 @@ bool CwssqlEx::onSetRelatedIndexes(IEspContext &context, IEspSetRelatedIndexesRe
 
         StringArray& indexHints = relatedIndexSet.getIndexes();
 
-        Owned<HPCCFile> file = HPCCFileCache::fetchHpccFileByName(fileName,username.str(), passwd, false);
-
-        if (!file)
-            throw MakeStringException(-1, "WsSQL::SetRelatedIndexes error: could not find file: %s.", fileName);
-
-        StringBuffer description;
-
-        StringBuffer currentIndexes;
-        description = file->getDescription();
-        HPCCFile::parseOutRelatedIndexes(description, currentIndexes);
-
         int indexHintsCount = indexHints.length();
         if (indexHintsCount > 0)
         {
+            Owned<HPCCFile> file = HPCCFileCache::fetchHpccFileByName(fileName,username.str(), passwd, false);
+
+            if (!file)
+                throw MakeStringException(-1, "WsSQL::SetRelatedIndexes error: could not find file: %s.", fileName);
+
+            StringBuffer description;
+
+            StringBuffer currentIndexes;
+            description = file->getDescription();
+            HPCCFile::parseOutRelatedIndexes(description, currentIndexes);
+
             description.append("\nXDBC:RelIndexes=[");
             for(int indexHintIndex = 0; indexHintIndex < indexHintsCount; indexHintIndex++)
             {

--- a/esp/services/ws_sql/ws_sqlService.hpp
+++ b/esp/services/ws_sql/ws_sqlService.hpp
@@ -109,6 +109,8 @@ public:
     bool onGetDBSystemInfo(IEspContext &context, IEspGetDBSystemInfoRequest &req, IEspGetDBSystemInfoResponse &resp);
     bool onGetDBMetaData(IEspContext &context, IEspGetDBMetaDataRequest &req, IEspGetDBMetaDataResponse &resp);
     bool onGetResults(IEspContext &context, IEspGetResultsRequest &req, IEspGetResultsResponse &resp);
+    bool onGetRelatedIndexes(IEspContext &context, IEspGetRelatedIndexesRequest &req, IEspGetRelatedIndexesResponse &resp);
+    bool onSetRelatedIndexes(IEspContext &context, IEspSetRelatedIndexesRequest &req, IEspSetRelatedIndexesResponse &resp);
     void refreshValidClusters();
     bool isValidCluster(const char *cluster);
 


### PR DESCRIPTION
- Added methods for reading DFU file descriptions, and interpreting
  related index annotations, and also setting those annotations

Signed-off-by: rpastrana <rodrigo.pastrana@lexisnexis.com>