### PR TITLE
WSSQL-107 Changes to keep up with HPCC platform master

### DIFF
--- a/esp/services/ws_sql/SQL2ECL/ECLEngine.cpp
+++ b/esp/services/ws_sql/SQL2ECL/ECLEngine.cpp
@@ -427,7 +427,7 @@ void ECLEngine::generateConstSelectDataset(HPCCSQLTreeWalker * selectsqlobj, IPr
 
     datasetStructSB.append("}],SelectStruct)");
 
-    eclEntities->setProp("CONSTDATASETSTRUCT", datasetStructSB.toCharArray());
+    eclEntities->setProp("CONSTDATASETSTRUCT", datasetStructSB.str());
 }
 
 void ECLEngine::generateSelectStruct(HPCCSQLTreeWalker * selectsqlobj, IProperties* eclEntities,  const IArrayOf<ISQLExpression> & expectedcolumns, const char * datasource)
@@ -574,7 +574,7 @@ void ECLEngine::generateSelectStruct(HPCCSQLTreeWalker * selectsqlobj, IProperti
     }
     selectStructSB.append("END;\n");
 
-    eclEntities->setProp("SELECTSTRUCT", selectStructSB.toCharArray());
+    eclEntities->setProp("SELECTSTRUCT", selectStructSB.str());
 }
 
 bool containsPayload(const HPCCFile * indexfiletotest, const HPCCSQLTreeWalker * selectsqlobj)

--- a/esp/services/ws_sql/SQL2ECL/HPCCFile.cpp
+++ b/esp/services/ws_sql/SQL2ECL/HPCCFile.cpp
@@ -119,7 +119,7 @@ bool HPCCFile::getFileRecDef(StringBuffer & out, const char * structname, const 
         ForEachItemIn(rowindex, this->columns)
         {
            out.append(recordindent);
-           out.append(this->columns.item(rowindex).toEclRecString().toCharArray());
+           out.append(this->columns.item(rowindex).toEclRecString().str());
            out.append(";");
            out.append(linedelimiter);
         }
@@ -155,7 +155,7 @@ bool HPCCFile::getFileRecDefwithIndexpos(HPCCColumnMetaData * fieldMetaData, Str
         ForEachItemIn(rowindex, this->columns)
         {
            out.append("\t");
-           out.append(this->columns.item(rowindex).toEclRecString().toCharArray());
+           out.append(this->columns.item(rowindex).toEclRecString().str());
            out.append(";");
            out.append("\n");
         }
@@ -211,10 +211,10 @@ bool HPCCFile::setFileColumns(const char * eclString)
       colsize = fields->query().getPropInt("@size", -1);
       colindex = fields->query().getPropInt("@position", -1);
 
-      Owned<HPCCColumnMetaData> col = HPCCColumnMetaData::createHPCCColumnMetaData(colname.toCharArray());
-      col->setColumnType(ecltype.toCharArray());
+      Owned<HPCCColumnMetaData> col = HPCCColumnMetaData::createHPCCColumnMetaData(colname.str());
+      col->setColumnType(ecltype.str());
       col->setIndex(colindex);
-      col->setTableName(this->fullname.toCharArray());
+      col->setTableName(this->fullname.str());
 
       columns.append(*LINK(col));
     }

--- a/esp/services/ws_sql/SQL2ECL/SQLColumn.hpp
+++ b/esp/services/ws_sql/SQL2ECL/SQLColumn.hpp
@@ -48,7 +48,7 @@ public:
 
     const char * getAlias() const
     {
-        return alias.toCharArray();
+        return alias.str();
     }
 
     void setAlias(const char * alias)
@@ -58,7 +58,7 @@ public:
 
     const char * getName()
     {
-        return name.toCharArray();
+        return name.str();
     }
 
     void setName(const char * name)
@@ -68,7 +68,7 @@ public:
 
     const char *  getParenttable() const
     {
-        return parenttable.toCharArray();
+        return parenttable.str();
     }
 
     void setParenttable(const char * parenttable)
@@ -92,14 +92,14 @@ public:
     const char * getColumnNameOrAlias()
     {
         if (alias.length() > 0)
-            return alias.toCharArray();
+            return alias.str();
         else
-            return name.toCharArray();
+            return name.str();
     }
 
     const char * getColumnType() const
     {
-       return columnType.toCharArray();
+       return columnType.str();
     }
 
     void setColumnType(const char* columnType)
@@ -156,9 +156,9 @@ public:
     StringBuffer toEclRecString()
     {
         StringBuffer result;
-        result.append(this->columnType.toCharArray());
+        result.append(this->columnType.str());
         result.append(" ");
-        result.append(this->columnName.toCharArray());
+        result.append(this->columnName.str());
 
         return result;
     }

--- a/esp/services/ws_sql/SQL2ECL/SQLExpression.cpp
+++ b/esp/services/ws_sql/SQL2ECL/SQLExpression.cpp
@@ -491,11 +491,11 @@ bool SQLBinaryExpression::isEqualityCondition(IProperties * map, const char * fi
         return false;
 
     return (
-                strcmp(operand1Translate.toCharArray(), operand2Translate.toCharArray()) != 0 &&
+                strcmp(operand1Translate.str(), operand2Translate.str()) != 0 &&
                 (
-                        (strcmp(operand1Translate.toCharArray(), first)==0 || strcmp(operand2Translate.toCharArray(), first)==0)
+                        (strcmp(operand1Translate.str(), first)==0 || strcmp(operand2Translate.str(), first)==0)
                         &&
-                        (strcmp(operand1Translate.toCharArray(), second)==0 || strcmp(operand2Translate.toCharArray(), second)==0)
+                        (strcmp(operand1Translate.str(), second)==0 || strcmp(operand2Translate.str(), second)==0)
                 )
             );
 }

--- a/esp/services/ws_sql/SQL2ECL/SQLExpression.hpp
+++ b/esp/services/ws_sql/SQL2ECL/SQLExpression.hpp
@@ -331,7 +331,7 @@ public:
 
     const char* getTable() const
     {
-        return this->table.toCharArray();
+        return this->table.str();
     }
 
     void setTable(const char* table)
@@ -735,7 +735,7 @@ public:
                     bool funcParam,
                     bool countFuncParam)
     {
-        eclStr.append( value.toCharArray() );
+        eclStr.append( value.str() );
     }
 
     SQLExpressionType getExpType()

--- a/esp/services/ws_sql/ws_sqlService.cpp
+++ b/esp/services/ws_sql/ws_sqlService.cpp
@@ -908,14 +908,14 @@ bool CwssqlEx::onExecuteSQL(IEspContext &context, IEspExecuteSQLRequest &req, IE
                 ecltext.appendf(EMBEDDEDSQLQUERYCOMMENT, sqltext.str(), normalizedSQL.str());
 
 #if defined _DEBUG
-                fprintf(stderr, "GENERATED ECL:\n%s\n", ecltext.toCharArray());
+                fprintf(stderr, "GENERATED ECL:\n%s\n", ecltext.str());
 #endif
                 if (isEmpty(ecltext))
                    throw MakeStringException(1,"Could not generate ECL from SQL.");
 
                 ESPLOG(LogMax, "WsSQL: creating new WU...");
                 NewWsWorkunit wu(context);
-                wu->getWuid(compiledwuid);
+                compiledwuid.set(wu->queryWuid());
 
                 wu->setJobName("WsSQL Job");
 
@@ -1339,7 +1339,7 @@ bool CwssqlEx::onPrepareSQL(IEspContext &context, IEspPrepareSQLRequest &req, IE
 
                 ECLEngine::generateECL(parsedSQL,ecltext);
 #if defined _DEBUG
-                fprintf(stderr, "GENERATED ECL:\n%s\n", ecltext.toCharArray());
+                fprintf(stderr, "GENERATED ECL:\n%s\n", ecltext.str());
 #endif
 
                 if (isEmpty(ecltext))
@@ -1349,7 +1349,7 @@ bool CwssqlEx::onPrepareSQL(IEspContext &context, IEspPrepareSQLRequest &req, IE
                 ecltext.appendf(EMBEDDEDSQLQUERYCOMMENT, sqltext.str(), normalizedSQL.str());
 
                 NewWsWorkunit wu(context);
-                wu->getWuid(wuid);
+                wuid.set(wu->queryWuid());
                 wu->setClusterName(cluster);
                 wu->setCloneable(true);
                 wu->setAction(WUActionCompile);
@@ -1747,7 +1747,7 @@ bool CwssqlEx::onCreateTableAndLoad(IEspContext &context, IEspCreateTableAndLoad
 
     NewWsWorkunit wu(context);
     SCMStringBuffer compiledwuid;
-    wu->getWuid(compiledwuid);
+    compiledwuid.set(wu->queryWuid());
 
     wu->setJobName("WsSQL Create table");
     wu.setQueryText(ecl.str());
@@ -1897,7 +1897,7 @@ bool CwssqlEx::publishWorkunit(IEspContext &context, const char * queryname, con
     if (notEmpty(queryname))
         queryName.set(queryname);
     else
-        cw->getJobName(queryName).str();
+        queryName.set(cw->queryJobName());
 
     if (!queryName.length())
         throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Query/Job name not defined for publishing workunit %s", wuid);
@@ -1906,7 +1906,7 @@ bool CwssqlEx::publishWorkunit(IEspContext &context, const char * queryname, con
     if (notEmpty(targetcluster))
         target.set(targetcluster);
     else
-        cw->getClusterName(target);
+        target.set(cw->queryClusterName());
 
     if (!target.length())
         throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Cluster name not defined for publishing workunit %s", wuid);


### PR DESCRIPTION
- StringBuffer no longer has tochararray()
- WU no longer has getXXX methods, use queryXXX instead

Signed-off-by: rpastrana <rodrigo.pastrana@lexisnexis.com>