### PR TITLE
WSSQL-116 Re-arrange schema tree generation

### DIFF
--- a/esp/services/ws_sql/SQL2ECL/ANTLR3c/HPCCSQL.g
+++ b/esp/services/ws_sql/SQL2ECL/ANTLR3c/HPCCSQL.g
@@ -936,7 +936,12 @@ subquery
 
 table_spec
 :
-  schema_spec ? (table_name | quoted_table_name)^
+  schema_spec? table_fork ->  ^(table_fork  schema_spec?)
+;
+
+table_fork
+:
+    (table_name | quoted_table_name)^
 ;
 
 schema_spec


### PR DESCRIPTION
- Schema portion should appear as child node of table name node

Signed-off-by: rpastrana <rodrigo.pastrana@lexisnexis.com>