### PR TITLE
WSSQL-122 Altered ws_sql build to target correct library for antlr

### DIFF
--- a/cmake_modules/buildANTLR3c.cmake
+++ b/cmake_modules/buildANTLR3c.cmake
@@ -99,7 +99,6 @@ IF (NOT ANTLR3c_FOUND)
     add_dependencies(libantlr3c_external DEPENDS libantlr3c-3.4-expand)
 
     add_library(libantlr3c UNKNOWN IMPORTED)
-    #add_library(libantlr3c STATIC IMPORTED)
     set_property(TARGET libantlr3c PROPERTY IMPORTED_LOCATION ${ANTLRcBUILDLOCATION_LIBRARY}/${ANTLR3c_lib})
 
     add_dependencies(libantlr3c libantlr3c_external)

--- a/esp/services/ws_sql/CMakeLists.txt
+++ b/esp/services/ws_sql/CMakeLists.txt
@@ -120,5 +120,5 @@ TARGET_LINK_LIBRARIES (
         securesocket
         dalibase
 
-        ${ANTLR3c_LIBRARIES}
+        ${libantlr3c}
     )


### PR DESCRIPTION
Signed-off-by: Michael Gardner <michael.gardner@lexisnexis.com>

@rpastrana If you can please test to make sure this works.  It now installs fine and doesn't list libantlr3c.so as a dependency for the RPM.  The libraries we were building were pointing to a normal variable instead of a library target.