### PR TITLE
WSSQL-131 Address memleak issues in getdbmetadata

### DIFF
--- a/esp/services/ws_sql/SQL2ECL/HPCCFile.cpp
+++ b/esp/services/ws_sql/SQL2ECL/HPCCFile.cpp
@@ -48,61 +48,21 @@ bool HPCCFile::validateFileName(const char * fullname)
     if (!fullname || !*fullname)
         return false;
 
-    pHPCCSQLLexer hpccSqlLexer = NULL;
-    pANTLR3_COMMON_TOKEN_STREAM sqlTokens = NULL;
-    pANTLR3_INPUT_STREAM sqlInputStream = NULL;
-
-    try
+    int len = strlen(fullname);
+    for (int strindex = 0; strindex < len; strindex++)
     {
-
-        pANTLR3_UINT8 input_string = (pANTLR3_UINT8)fullname;
-        pANTLR3_INPUT_STREAM sqlinputstream = antlr3StringStreamNew(input_string,
-                ANTLR3_ENC_8BIT,
-                strlen(fullname),
-                (pANTLR3_UINT8)"File Name");
-
-        pHPCCSQLLexer hpccsqllexer = HPCCSQLLexerNew(sqlinputstream);
-
-        pANTLR3_COMMON_TOKEN_STREAM sqltokens = antlr3CommonTokenStreamSourceNew(ANTLR3_SIZE_HINT, TOKENSOURCE(hpccsqllexer));
-        if (sqltokens == NULL)
+        switch (fullname[strindex])
         {
-            throw MakeStringException(-1, "Out of memory trying to allocate ANTLR HPCCSQLParser token stream.");
-        }
-
-        pANTLR3_VECTOR tvect = sqltokens->getTokens(sqltokens);
-        for (int i = 0; i < tvect->count; i++)
-        {
-            pANTLR3_COMMON_TOKEN  token = (pANTLR3_COMMON_TOKEN  )tvect->get(tvect, i);
-            if (token->type != ID && token->type != ABSOLUTE_FILE_ID_PREFIX && token->type != ABSOLUTE_FILE_ID)
-            {
-#if defined _DEBUG
-    fprintf(stderr, "\nNot reporting file %s as supported.\n", fullname);
-#endif
+            case '\'':
+            case '\"':
                 return false;
-            }
+            case '~':
+                if (strindex > 0)
+                    return false;
+                break;
+            default:
+                break;
         }
-
-        sqltokens->free(sqltokens);
-        hpccsqllexer->free(hpccsqllexer);
-        sqlinputstream->free(sqlinputstream);
-    }
-    catch(...)
-    {
-        try
-        {
-            if (sqlTokens)
-                sqlTokens->free(sqlTokens);
-            if (hpccSqlLexer)
-                hpccSqlLexer->free(hpccSqlLexer);
-            if (sqlInputStream)
-                sqlInputStream->free(sqlInputStream);
-        }
-        catch (...)
-        {
-            ERRLOG("!!! Unable to free HPCCSQL parser/lexer objects.");
-        }
-
-        return false;
     }
 
     return true;

--- a/esp/services/ws_sql/SQL2ECL/HPCCFileCache.cpp
+++ b/esp/services/ws_sql/SQL2ECL/HPCCFileCache.cpp
@@ -115,6 +115,7 @@ bool HPCCFileCache::cacheAllHpccFiles(const char * filterby)
        StringBuffer name(attr.queryProp("@name"));
 
        if (name.length()>0 && HPCCFile::validateFileName(name.str()))
+       //if (name.length()>0)
        {
            const char * cachedKey = cacheHpccFileByName(name.str(), true);
            success &= (cachedKey && *cachedKey);
@@ -287,8 +288,18 @@ HPCCFile * HPCCFileCache::fetchHpccFileByName(const char * filename, const char 
 
         if (file && ( file->containsNestedColumns() || strncmp(file->getFormat(), "XML", 3)==0))
             throw MakeStringException(-1,"Nested data files not supported: %s.",filename);
-
     }
+
+    catch (IException * se)
+    {
+        StringBuffer s;
+        se->errorMessage(s);
+        DBGLOG("Error fetching file %s info: %s", filename, s.str());
+        se->Release();
+        if (file)
+            file.clear();
+    }
+
     catch (...)
     {
         if (file)


### PR DESCRIPTION
- Do not use ANTLR lexer to validate filenames
- Release exception caught

Signed-off-by: rpastrana <rodrigo.pastrana@lexisnexis.com>