### PR TITLE
WSSQL-134 Restrict wssql install to compatible HPCC minor versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,11 +255,12 @@ IF ( NOT MAKE_DOCS_ONLY )
         SET(HPCC_VERSION "${HPCC_MAJOR}.${HPCC_MINOR}.${HPCC_POINT}")
     ENDIF()
 
-    MATH( EXPR ceiling "${HPCC_MAJOR} + 1" )
-    SET(HPCC_VERSION_CEILING "${ceiling}.0.0")
+    MATH( EXPR minor_ceiling "${HPCC_MINOR} + 1")
+    SET(HPCC_VERSION_CEILING "${HPCC_MAJOR}.${minor_ceiling}.0")
 
-    MESSAGE("-- Minimum HPCC Platform version required: ${HPCC_MAJOR_REQ}.${HPCC_MINOR_REQ}")
-    MESSAGE("--- Building against HPCC Platform version: ${HPCC_MAJOR}.${HPCC_MINOR}.${HPCC_POINT}-${HPCC_MATURITY}${HPCC_SEQUENCE}")
+    MESSAGE("-- Building against HPCC Platform version: ${HPCC_MAJOR}.${HPCC_MINOR}.${HPCC_POINT}-${HPCC_MATURITY}${HPCC_SEQUENCE}")
+    MESSAGE("--- Minimum buildtime HPCC Platform version required: ${HPCC_MAJOR_REQ}.${HPCC_MINOR_REQ}")
+    MESSAGE("--- Maximum runtime HPCC Platform version allowed:  ${HPCC_VERSION_CEILING}")
 
     IF (${HPCC_MAJOR_REQ} GREATER ${HPCC_MAJOR} OR ( ${HPCC_MAJOR_REQ} EQUAL ${HPCC_MAJOR} AND ${HPCC_MINOR_REQ} GREATER ${HPCC_MINOR} ))
         MESSAGE(FATAL_ERROR "Project ${project} requires HPCC Platform version ${HPCC_MAJOR_REQ}.${HPCC_MINOR_REQ} or greater." )

--- a/platform-version-prereq.cmake
+++ b/platform-version-prereq.cmake
@@ -3,9 +3,10 @@
 ## The WSSQL ESP plug-in must be built against an HPCC 
 ## source tree of at least this version: 
 ###
+
 set ( HPCC_PROJECT_REQ "community" )
-set ( HPCC_MAJOR_REQ 5 )
-set ( HPCC_MINOR_REQ 2 )
+set ( HPCC_MAJOR_REQ 6 )
+set ( HPCC_MINOR_REQ 0 )
 set ( HPCC_POINT_REQ 0 )
 set ( HPCC_MATURITY_REQ "trunk" )
 set ( HPCC_SEQUENCE_REQ 1 )


### PR DESCRIPTION
Restrict wssql install to compatible HPCC minor versions

Signed-off-by: rpastrana <rodrigo.pastrana@lexisnexis.com>