### PR TITLE
wssql-143 Remove DEPENDS keyword from add_dependencies call

### DIFF
--- a/cmake_modules/buildANTLR3c.cmake
+++ b/cmake_modules/buildANTLR3c.cmake
@@ -97,7 +97,7 @@ IF (NOT ANTLR3c_FOUND)
         BUILD_IN_SOURCE 1
     )
 
-    add_dependencies(libantlr3c_external DEPENDS ${ANTLRcPACKAGENAME}-expand)
+    add_dependencies(libantlr3c_external ${ANTLRcPACKAGENAME}-expand)
 
     add_library(libantlr3c SHARED IMPORTED GLOBAL)
     set_property(TARGET libantlr3c PROPERTY IMPORTED_LOCATION ${ANTLRcBUILDLOCATION_LIBRARY}/${ANTLR3c_lib})


### PR DESCRIPTION
Also changed libantlr3c-3.4-expand to ${ANTLRcPACKAGENAME}-expand so it matches previous declarations.

Signed-off-by: Michael Gardner <michael.gardner@lexisnexis.com>