### PR TITLE
WSSQL-155 latestDS should be set everytime

### DIFF
--- a/esp/services/ws_sql/SQL2ECL/ECLEngine.cpp
+++ b/esp/services/ws_sql/SQL2ECL/ECLEngine.cpp
@@ -268,7 +268,7 @@ void ECLEngine::generateSelectECL(HPCCSQLTreeWalker * selectsqlobj, StringBuffer
                 {
                     //Nth Join, previous DS is JndDS(N-1)
                     out.appendf("JndDS%d",tableidx-1);
-                    latestDS.appendf("JndDS%d",tableidx);
+                    latestDS.setf("JndDS%d",tableidx);
                 }
 
                 StringBuffer translatedAndFilteredOnClause;


### PR DESCRIPTION
- latestDS is set, not appended when referencing a join result

Signed-off-by: Rodrigo Pastrana <rodrigo.pastrana@lexisnexis.com>