### PR TITLE
WSSQL-165 Do not attempt to parameterize prepared queries

### DIFF
--- a/esp/services/ws_sql/SQL2ECL/HPCCSQLTreeWalker.hpp
+++ b/esp/services/ws_sql/SQL2ECL/HPCCSQLTreeWalker.hpp
@@ -101,6 +101,7 @@ private:
     int parameterizedCount;
 
     StringBuffer normalizedSQL;
+    bool parameterizeStaticValues;
 
 public:
 
@@ -136,7 +137,8 @@ public:
 
     void expandWildCardColumn();
     HPCCSQLTreeWalker();
-    HPCCSQLTreeWalker(pANTLR3_BASE_TREE t, IEspContext &context);
+    HPCCSQLTreeWalker(pANTLR3_BASE_TREE t, IEspContext &context, bool attemptParameterization = true);
+
     virtual ~HPCCSQLTreeWalker();
 
     int getParameterizedCount() const

--- a/esp/services/ws_sql/ws_sqlService.cpp
+++ b/esp/services/ws_sql/ws_sqlService.cpp
@@ -567,7 +567,7 @@ void myDisplayRecognitionError (pANTLR3_BASE_RECOGNIZER recognizer,pANTLR3_UINT8
     throw MakeStringException(-1, "%s", errorMessage.str());
 }
 
-HPCCSQLTreeWalker * CwssqlEx::parseSQL(IEspContext &context, StringBuffer & sqltext)
+HPCCSQLTreeWalker * CwssqlEx::parseSQL(IEspContext &context, StringBuffer & sqltext, bool attemptParameterization)
 {
     int limit = -1;
     pHPCCSQLLexer hpccSqlLexer = NULL;
@@ -615,7 +615,7 @@ HPCCSQLTreeWalker * CwssqlEx::parseSQL(IEspContext &context, StringBuffer & sqlt
 printTree(sqlAST, 0);
 #endif
 
-        hpccSqlTreeWalker.setown(new HPCCSQLTreeWalker(sqlAST, context));
+        hpccSqlTreeWalker.setown(new HPCCSQLTreeWalker(sqlAST, context, attemptParameterization));
 
         hpccsqlparser->free(hpccsqlparser);
         sqltokens->free(sqltokens);
@@ -1355,7 +1355,7 @@ bool CwssqlEx::onPrepareSQL(IEspContext &context, IEspPrepareSQLRequest &req, IE
             throw MakeStringException(1,"Empty SQL request.");
 
         Owned<HPCCSQLTreeWalker> parsedSQL;
-        parsedSQL.setown(parseSQL(context, sqltext));
+        parsedSQL.setown(parseSQL(context, sqltext, false));
 
         if (parsedSQL->getSqlType() == SQLTypeCall)
         {

--- a/esp/services/ws_sql/ws_sqlService.hpp
+++ b/esp/services/ws_sql/ws_sqlService.hpp
@@ -121,7 +121,7 @@ public:
 
     void fetchRequiredHpccFiles(IArrayOf<SQLTable> * sqltables);
     static void fetchRequiredHpccFiles(IArrayOf<SQLTable> * sqltables, HpccFiles * hpccfilecache);
-    HPCCSQLTreeWalker * parseSQL(IEspContext &context, StringBuffer & sqltext);
+    HPCCSQLTreeWalker * parseSQL(IEspContext &context, StringBuffer & sqltext, bool attemptParameterization = true);
 
     bool executePublishedQueryByName(IEspContext &context, const char * queryset, const char * queryname, StringBuffer &clonedwuid, const char *paramXml, IArrayOf<IConstNamedValue> *variables, const char * targetcluster, int start, int count);
     bool executePublishedQueryByWuId(IEspContext &context, const char * targetwuid, StringBuffer &clonedwuid, const char *paramXml, IArrayOf<IConstNamedValue> *variables, const char * targetcluster, int start, int count);


### PR DESCRIPTION
- Adds Treewalker member var to track option to attempt parameterization
- PrepareSQL logic opts out of parameterization attempt

Signed-off-by: Rodrigo Pastrana <rodrigo.pastrana@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC WsSQL project

 PLEASE READ the following before proceeding.

 Lines in comments may be deleted from the comment before you submit.
 Other lines should be modified appropriately and left in place.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 WSSQL-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [x] The change has been fully tested:
  - [x] I have performed unit tests to cover my changes.
  - [x] I have performed system test and covered possible regressions and side effects.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
